### PR TITLE
Fix php8.1 compatibility

### DIFF
--- a/.github/workflows/phpunit-symfony6.yml
+++ b/.github/workflows/phpunit-symfony6.yml
@@ -12,6 +12,7 @@ jobs:
           - ubuntu-latest
         php:
           - 8.0
+          - 8.1
 
     name: php${{ matrix.php }} - symfony 6
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,6 +12,7 @@ jobs:
           - ubuntu-latest
         php:
           - 8.0
+          - 8.1
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: php${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": "^8.0",
     "ext-json": "*",
     "dogado/json-api-common": "^2.0",
-    "symfony/validator": "^5.2"
+    "symfony/validator": "^5.3.7"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
This PR fixes the compatibility with php 8.1. The `symfony/validator` requirement had to be changed due to [bug #42260](https://github.com/symfony/validator/releases/tag/v5.3.7).