### PR TITLE
Instantiate request handlers on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0 - 2021-11-XX
+
+- add ability to register request handlers as callable to instantiate them on demand to reduce memory load
+
 ## v3.0.0 - 2021-10-04
 
 - require `dogado/json-api-common:^3.0`

--- a/docs/01-json-api-server.md
+++ b/docs/01-json-api-server.md
@@ -45,8 +45,8 @@ use Dogado\JsonApi\Model\Request\Request;
 // create the server
 $jsonApi = new JsonApiServer(new Deserializer(), new Serializer());
 
-// add your request handlers to the registry of the json api server
-$jsonApi->addHandler('customResources', new YourCustomRequestHandler());
+// Add your request handlers to the registry of the json api server. You can either pass an instance or a callable.
+$jsonApi->addHandler('customResources', fn () => new YourCustomRequestHandler());
 
 // create the json api request
 $request = new Request(

--- a/docs/01-json-api-server.md
+++ b/docs/01-json-api-server.md
@@ -4,13 +4,13 @@
 
 `Dogado\JsonApi\Server\JsonApiServer`:
 
-| Method                                                      | Return Type            | Description                                                    |
-|-------------------------------------------------------------|------------------------|----------------------------------------------------------------|
-| addHandler(string $type, RequestHandlerInterface $handler)  | void                   | Adds a request handler                                         |
-| createRequestBody(?string $requestBody)                     | DocumentInterface/null | Creates a document from the given string                       |
-| handleRequest(RequestInterface $request)                    | ResponseInterface      | Handles a request to generate a response                       |
-| createResponseBody(ResponseInterface $response)             | string                 | Creates the (http) response body for a given json api response |
-| handleException(\Throwable $throwable, bool $debug = false) | ResponseInterface      | Creates a response for an exception                            |
+| Method                                                              | Return Type            | Description
+|---------------------------------------------------------------------|------------------------|----------------------------------------------------------------
+| addHandler(string $type, RequestHandlerInterface\|callable $handler) | void                   | Adds a request handler. Can be a callable to instantiate request handlers on demand to reduce memory load.
+| createRequestBody(?string $requestBody)                             | DocumentInterface/null | Creates a document from the given string
+| handleRequest(RequestInterface $request)                            | ResponseInterface      | Handles a request to generate a response
+| createResponseBody(ResponseInterface $response)                     | string                 | Creates the (http) response body for a given json api response
+| handleException(\Throwable $throwable, bool $debug = false)         | ResponseInterface      | Creates a response for an exception
 
 ## Table of contents
 


### PR DESCRIPTION
This pull request adds the feature to additionally register request handlers as callable, so that the request handlers would only be instantiated on demand and then would be reused.

Closes #11.